### PR TITLE
Move the store object out of the ContentEditor

### DIFF
--- a/src/js/content-editor.js
+++ b/src/js/content-editor.js
@@ -1,15 +1,12 @@
 import React, { Component, PropTypes } from 'react';
 import { Parser } from './parser';
-import { store } from './store';
-import { http } from './store/adapters';
 import { autobind } from 'core-decorators';
-
-const contentStore = store(http);
 
 export default class ContentEditor extends Component {
   static propTypes = {
     template: PropTypes.string,
-    componentsStyle: PropTypes.string
+    componentsStyle: PropTypes.string,
+    store: PropTypes.object
   };
 
   constructor(props) {
@@ -30,9 +27,10 @@ export default class ContentEditor extends Component {
     console.info(Parser.compileTemplate({ template }));
   }
 
+  @autobind
   saveData() {
     const pluginDataMap = Parser.getPluginData();
-    contentStore.save(pluginDataMap)
+    this.props.store.save(pluginDataMap)
       .then(({ pluginId, path: value }) => Parser.updatePluginData({ pluginId, value }));
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,11 @@ import 'babel-polyfill';
 import ContentEditor from './js/content-editor';
 import React from 'react';
 import { render } from 'react-dom';
+import { store } from './js/store';
+import { http } from './js/store/adapters';
+
+
+const contentStore = store(http);
 
 const style = `
 div.outter {
@@ -21,6 +26,6 @@ const template = `
 `;
 
 render(
-  <ContentEditor template={ template } componentsStyle={ style } />,
+  <ContentEditor template={ template } componentsStyle={ style } store={ contentStore } />,
   document.querySelector('.editor')
 );


### PR DESCRIPTION
In order to provide more flexibility as per the store implementation
goes, remove the store from the ContentEditor in order for it to become
a prop to be passed. So if one desires to implement their own store, all
it takes is to follow the store API structure.
